### PR TITLE
clientToken Migration

### DIFF
--- a/Sources/Base/OAuth2KeychainAccount.swift
+++ b/Sources/Base/OAuth2KeychainAccount.swift
@@ -60,7 +60,12 @@ struct OAuth2KeychainAccount: KeychainGenericPasswordType {
 		data = inData
 	}
 	
-	init(oauth2: OAuth2Securable, account: String, data inData: [String: Any] = [:],_serviceName:String = "") {
+	/**
+	Designated initializer.
+	- parameter _serviceName:  The OAuth2 instance Keychain Entry Name
+	*/
+	
+	init(oauth2: OAuth2Securable, account: String, data inData: [String: Any] = [:],_serviceName:String) {
 		serviceName = _serviceName
 		accountName = account
 		accessMode = String(oauth2.keychainAccessMode)

--- a/Sources/Base/OAuth2KeychainAccount.swift
+++ b/Sources/Base/OAuth2KeychainAccount.swift
@@ -59,6 +59,15 @@ struct OAuth2KeychainAccount: KeychainGenericPasswordType {
 		accessGroup = oauth2.keychainAccessGroup
 		data = inData
 	}
+	
+	init(oauth2: OAuth2Securable, account: String, data inData: [String: Any] = [:],_serviceName:String = "") {
+		serviceName = _serviceName
+		accountName = account
+		accessMode = String(oauth2.keychainAccessMode)
+		accessGroup = oauth2.keychainAccessGroup
+		data = inData
+	}
+		
 }
 
 


### PR DESCRIPTION
macOS Client Tokens Generic as per app name

- old clientTokens will be migrated to newFromat
- newFormat is ProductName:BundleID:PersonalAccessToken

Signed-off-by: Arsalan <arsalan.ghaffar@purevpn.com>